### PR TITLE
Feature/upvote downvote post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.3'
 
+gem 'acts_as_votable'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'cancancan'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts_as_votable (0.13.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -307,6 +308,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_votable
   bootsnap (>= 1.4.4)
   byebug
   cancancan

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -50,6 +50,7 @@ form {
         flex-direction: column;
         justify-content: center;
         align-items: center;
+        margin-right: 1vw;
       }
     }
     .post__content {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -34,9 +34,21 @@ form {
     font-size: 1rem;
     margin-top: -1rem;
   }
-  .post__content {
-    margin-top: 1rem;
-    margin-bottom: 4rem;
+  .post__body {
+    display: flex;
+    turbo-frame {
+      display: flex;
+      .vote {
+        flex: 25%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+    .content {
+      margin: 1rem 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -54,6 +54,7 @@ form {
       }
     }
     .post__content {
+      width: 90%;
       margin: 1rem 0;
     }
   }

--- a/app/controllers/posts/votes_controller.rb
+++ b/app/controllers/posts/votes_controller.rb
@@ -6,8 +6,7 @@ module Posts
     before_action :set_post
 
     def create
-      post_params[:vote] == 'true' ? current_user.up_votes(@post) : current_user.down_votes(@post)
-      render turbo_stream: turbo_stream.update("vote_#{@post.id}", partial: 'posts/votes/vote', locals: { post: @post })
+      post_params[:vote] == '+' ? current_user.up_votes(@post) : current_user.down_votes(@post)
     end
 
     private

--- a/app/controllers/posts/votes_controller.rb
+++ b/app/controllers/posts/votes_controller.rb
@@ -6,7 +6,7 @@ module Posts
     before_action :set_post
 
     def create
-      post_params[:vote] == '+' ? current_user.up_votes(@post) : current_user.down_votes(@post)
+      post_params[:vote] == 'up' ? current_user.up_votes(@post) : current_user.down_votes(@post)
     end
 
     private

--- a/app/controllers/posts/votes_controller.rb
+++ b/app/controllers/posts/votes_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Posts
+  class VotesController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_post
+
+    def create
+      post_params[:vote] == 'true' ? current_user.up_votes(@post) : current_user.down_votes(@post)
+      render turbo_stream: turbo_stream.update("vote_#{@post.id}", partial: 'posts/votes/vote', locals: { post: @post })
+    end
+
+    private
+
+    def post_params
+      params.require(:post).permit(:vote)
+    end
+
+    def set_post
+      @post = Post.find(params[:post_id])
+    end
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
 
   def index
-    @posts = Post.includes(:stack).accessible_by(current_ability).with_rich_text_body_and_embeds
+    @posts = Post.includes(:stack).accessible_by(current_ability).with_rich_text_body_and_embeds.order(:created_at)
     @posts = @posts.from_user(params[:user_id]) if params[:user_id]
     @posts = @posts.related_to(params[:search]) if params[:search]
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
+  acts_as_votable
+
   belongs_to :user
   belongs_to :stack
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[github]
 
+  acts_as_voter
+
   validates :email, :pseudo, uniqueness: true
 
   has_many :posts, dependent: :nullify

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -8,9 +8,7 @@
     </div>
     <div class='post__meta'><em><%= created_at_date(post) %></em></div>
     <div class="post__body">
-      <%= turbo_frame_tag "vote_#{post.id}" do %>
-        <%= render partial: 'posts/votes/vote', locals: { post: post} %>
-      <% end %>
+      <%= render partial: 'posts/votes/vote', locals: { post: post } %>
       <div class='post__content'>
         <%= post.body %>
       </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,12 @@
 <div class="post">
   <h2><%= link_to post.title, post_path(post), target: '_top' %></h2>
-  <p class='meta'><em><%= created_at_date(post) %> - <%= post.stack.name %></em></p>
-  <div class='content'>
-    <%= post.body %>
+  <p class="post__meta"><em><%= created_at_date(post) %> - <%= post.stack.name %></em></p>
+  <div class="post__body">
+    <%= turbo_frame_tag "vote_#{post.id}" do %>
+      <%= render partial: 'posts/votes/vote', locals: { post: post} %>
+    <% end %>
+    <div class="content">
+      <%= post.body %>
+    </div>
   </div>
 </div>

--- a/app/views/posts/votes/_form.html.erb
+++ b/app/views/posts/votes/_form.html.erb
@@ -1,6 +1,13 @@
-<%= form_with url: post_votes_path(post), scope: :post do |f| %>
-  <%= f.hidden_field :vote, value: label %>
-  <%= button_tag type: 'submit', disabled: disable  do %>
+<% if user_signed_in? %>
+  <%= button_to post_votes_path(post, post: { vote: label }), method: :post, disabled: disable do %>
+    <% if label == '+' %>
+      <i class="fas fa-caret-up"></i>
+    <% else %>
+      <i class="fas fa-caret-down"></i>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= button_to new_user_session_path, method: :get do %>
     <% if label == '+' %>
       <i class="fas fa-caret-up"></i>
     <% else %>

--- a/app/views/posts/votes/_form.html.erb
+++ b/app/views/posts/votes/_form.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <%= button_to post_votes_path(post, post: { vote: label }), method: :post, disabled: disable do %>
-    <% if label == '+' %>
+    <% if label == 'up' %>
       <i class="fas fa-caret-up"></i>
     <% else %>
       <i class="fas fa-caret-down"></i>
@@ -8,7 +8,7 @@
   <% end %>
 <% else %>
   <%= button_to new_user_session_path, method: :get do %>
-    <% if label == '+' %>
+    <% if label == 'up' %>
       <i class="fas fa-caret-up"></i>
     <% else %>
       <i class="fas fa-caret-down"></i>

--- a/app/views/posts/votes/_form.html.erb
+++ b/app/views/posts/votes/_form.html.erb
@@ -1,4 +1,10 @@
 <%= form_with url: post_votes_path(post), scope: :post do |f| %>
   <%= f.hidden_field :vote, value: label %>
-  <%= f.submit label, disabled: disable %>
+  <%= button_tag type: 'submit', disabled: disable  do %>
+    <% if label == '+' %>
+      <i class="fas fa-caret-up"></i>
+    <% else %>
+      <i class="fas fa-caret-down"></i>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/posts/votes/_form.html.erb
+++ b/app/views/posts/votes/_form.html.erb
@@ -1,4 +1,4 @@
 <%= form_with url: post_votes_path(post), scope: :post do |f| %>
-  <%= f.hidden_field :vote, value: value %>
-  <%= f.submit (value ? '+' : '-' ), disabled: disabled %>
+  <%= f.hidden_field :vote, value: label %>
+  <%= f.submit label, disabled: disable %>
 <% end %>

--- a/app/views/posts/votes/_form.html.erb
+++ b/app/views/posts/votes/_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with url: post_votes_path(post), scope: :post do |f| %>
+  <%= f.hidden_field :vote, value: value %>
+  <%= f.submit (value ? '+' : '-' ), disabled: disabled %>
+<% end %>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,11 +1,13 @@
-<%= turbo_frame_tag "vote_#{post.id}" do %>
+<%= turbo_frame_tag "vote_#{post.id}", target: '_top' do %>
   <div class="vote">
-    <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: user_signed_in? ? current_user.voted_up_on?(post) : true } %>
-    <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
-    <% if post.get_upvotes.size.zero? %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: true } %>
+    <% if user_signed_in? %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: current_user.voted_up_on?(post) } %>
+      <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: current_user.voted_down_on?(post) } %>
     <% else %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: user_signed_in? ? current_user.voted_down_on?(post) : true } %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: false } %>
+      <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: false } %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,13 +1,13 @@
 <%= turbo_frame_tag "vote_#{post.id}", target: '_top' do %>
   <div class="vote">
     <% if user_signed_in? %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: current_user.voted_up_on?(post) } %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'up', disable: current_user.voted_up_on?(post) } %>
       <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: current_user.voted_down_on?(post) } %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'down', disable: current_user.voted_down_on?(post) } %>
     <% else %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: false } %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'up', disable: false } %>
       <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: false } %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'down', disable: false } %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,5 +1,11 @@
-<div class="vote">
-  <%= render partial: 'posts/votes/form', locals: { post: post, value: true, disabled: user_signed_in? ? current_user.voted_up_on?(post) : true } %>
-  <span class="vote__total"><%= post.weighted_score %></span>
-  <%= render partial: 'posts/votes/form', locals: { post: post, value: false, disabled: user_signed_in? ? current_user.voted_down_on?(post) : true } %>
-</div>
+<%= turbo_frame_tag "vote_#{post.id}" do %>
+  <div class="vote">
+    <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: user_signed_in? ? current_user.voted_up_on?(post) : true } %>
+    <span class="vote__total"><%= post.get_upvotes.size %></span>
+    <% if post.get_upvotes.size.zero? %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: true } %>
+    <% else %>
+      <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: user_signed_in? ? current_user.voted_down_on?(post) : true } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,13 +1,7 @@
 <%= turbo_frame_tag "vote_#{post.id}", target: '_top' do %>
   <div class="vote">
-    <% if user_signed_in? %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'up', disable: current_user.voted_up_on?(post) } %>
-      <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'down', disable: current_user.voted_down_on?(post) } %>
-    <% else %>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'up', disable: false } %>
-      <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
-      <%= render partial: 'posts/votes/form', locals: { post: post, label: 'down', disable: false } %>
-    <% end %>
+    <%= render partial: 'posts/votes/form', locals: { post: post, label: 'up', disable: current_user&.voted_up_on?(post) } %>
+    <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
+    <%= render partial: 'posts/votes/form', locals: { post: post, label: 'down', disable: current_user&.voted_down_on?(post) } %>
   </div>
 <% end %>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,0 +1,5 @@
+<div class="vote">
+  <%= render partial: 'posts/votes/form', locals: { post: post, value: true, disabled: user_signed_in? ? current_user.voted_up_on?(post) : true } %>
+  <span class="vote__total"><%= post.weighted_score %></span>
+  <%= render partial: 'posts/votes/form', locals: { post: post, value: false, disabled: user_signed_in? ? current_user.voted_down_on?(post) : true } %>
+</div>

--- a/app/views/posts/votes/_vote.html.erb
+++ b/app/views/posts/votes/_vote.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "vote_#{post.id}" do %>
   <div class="vote">
     <%= render partial: 'posts/votes/form', locals: { post: post, label: '+', disable: user_signed_in? ? current_user.voted_up_on?(post) : true } %>
-    <span class="vote__total"><%= post.get_upvotes.size %></span>
+    <span class="vote__total"><b><%= post.get_upvotes.size %></b></span>
     <% if post.get_upvotes.size.zero? %>
       <%= render partial: 'posts/votes/form', locals: { post: post, label: '-', disable: true } %>
     <% else %>

--- a/app/views/posts/votes/create.turbo_stream.erb
+++ b/app/views/posts/votes/create.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace("vote_#{@post.id}", partial: 'posts/votes/vote', locals: { post: @post }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
 
   devise_for :users, skip: [:registrations], controllers: { omniauth_callbacks: 'devise/omniauth' }
 
-  resources :posts
+  resources :posts do
+    resources :votes, only: :create, module: 'posts'
+  end
 
   namespace :users do
     resources :posts, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,16 +6,13 @@ Rails.application.routes.draw do
 
   devise_for :users, skip: [:registrations], controllers: { omniauth_callbacks: 'devise/omniauth' }
 
-  resources :posts do
-    resources :votes, only: :create, module: 'posts'
-  end
-
   namespace :users do
     resources :posts, only: :index
   end
 
   resources :posts do
     resources :bookmarks, only: %i[create]
+    resources :votes, only: :create, module: 'posts'
   end
 
   namespace :bookmarks do

--- a/db/migrate/20220114152300_acts_as_votable_migration.rb
+++ b/db/migrate/20220114152300_acts_as_votable_migration.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ActsAsVotableMigration < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :votes do |t|
+      t.references :votable, polymorphic: true
+      t.references :voter, polymorphic: true
+
+      t.boolean :vote_flag
+      t.string :vote_scope
+      t.integer :vote_weight
+
+      t.timestamps
+    end
+
+    add_index :votes, %i[voter_id voter_type vote_scope]
+    add_index :votes, %i[votable_id votable_type vote_scope]
+  end
+
+  def self.down
+    drop_table :votes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_18_170559) do
+ActiveRecord::Schema.define(version: 2022_01_14_152300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,13 +77,13 @@ ActiveRecord::Schema.define(version: 2021_12_18_170559) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: 6
+    t.datetime "remember_created_at", precision: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: 6
+    t.datetime "confirmation_sent_at", precision: 6
     t.string "unconfirmed_email"
     t.string "provider"
     t.string "uid"
@@ -91,6 +91,22 @@ ActiveRecord::Schema.define(version: 2021_12_18_170559) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "votes", force: :cascade do |t|
+    t.string "votable_type"
+    t.bigint "votable_id"
+    t.string "voter_type"
+    t.bigint "voter_id"
+    t.boolean "vote_flag"
+    t.string "vote_scope"
+    t.integer "vote_weight"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope"
+    t.index ["votable_type", "votable_id"], name: "index_votes_on_votable"
+    t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"
+    t.index ["voter_type", "voter_id"], name: "index_votes_on_voter"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,6 +20,10 @@ def post_bodies
     end
 end
 
+def random_post
+  Post.find(Post.pluck(:id).sample)
+end
+
 warn '==> Running stacks seeds'
 create_stacks
 warn '==> End of stacks seeds'
@@ -47,6 +51,13 @@ if Rails.env.development?
       user_id: admin.id,
       post_id: Post.ids.sample
     )
+  end
+
+  User.all.each do |user|
+    5.times do
+      user.up_votes(random_post)
+      user.down_votes(random_post)
+    end
   end
 
   warn '==> End of development environnement seed'

--- a/test/controllers/posts/votes_controller_test.rb
+++ b/test/controllers/posts/votes_controller_test.rb
@@ -5,12 +5,36 @@ require 'test_helper'
 class VotesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  setup do
+    @user = users(:post_owner)
+    @post = posts(:default)
+    sign_in @user
+  end
+
   test 'it should create an upvote' do
+    assert_difference -> { @post.get_upvotes.size } do
+      create_vote
+    end
   end
 
   test 'it should create a downvote' do
+    assert_difference -> { @post.get_downvotes.size } do
+      create_vote('-')
+    end
   end
 
   test 'it should update a vote' do
+    create_vote
+    assert_no_difference -> { @post.get_upvotes.size } do
+      create_vote
+    end
+  end
+
+  private
+
+  def create_vote(value = '+')
+    post post_votes_url(@post, params: { post: { vote: value } }, format: :turbo_stream)
+
+    assert_response :success
   end
 end

--- a/test/controllers/posts/votes_controller_test.rb
+++ b/test/controllers/posts/votes_controller_test.rb
@@ -19,7 +19,7 @@ class VotesControllerTest < ActionDispatch::IntegrationTest
 
   test 'it should create a downvote' do
     assert_difference -> { @post.get_downvotes.size } do
-      create_vote('-')
+      create_vote('down')
     end
   end
 
@@ -32,7 +32,7 @@ class VotesControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def create_vote(value = '+')
+  def create_vote(value = 'up')
     post post_votes_url(@post, params: { post: { vote: value } }, format: :turbo_stream)
 
     assert_response :success

--- a/test/controllers/posts/votes_controller_test.rb
+++ b/test/controllers/posts/votes_controller_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class VotesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'it should create an upvote' do
+  end
+
+  test 'it should create a downvote' do
+  end
+
+  test 'it should update a vote' do
+  end
+end


### PR DESCRIPTION
# Feature: Upvote and downvote a post

## Description:
Give to a **logged user** the ability to upvote and downvote a post. If the user is not logged, he will be redirected to the SignUp page. The user **can vote only once**, after voting the button becomes disabled and he needs to vote to opposite to re-enable the previous one.

Example: _User A_ upvotes _Post A_, the upvote button is now disabled. _User A_ downvotes _Post A_, the downvote button is disabled and the upvote one enabled.

## Technical features:
For this feature we're using the gem [acts_as_votable](https://github.com/ryanto/acts_as_votable).

When a user changes his vote, (ex: upvotes then downvotes), there's no new record created, the vote record is updated with a new value.

The total of votes shown, is the number of upvotes the post has. This means, there can't be negative totals. If we want to include negative totals, we need to implement a system of point (aka reputation in StackOverflow) IMHO, to avoid any abuse.